### PR TITLE
support useNoBackupDirectory on Android SDK 23 and higher

### DIFF
--- a/library/src/test/java/com/github/reline/sqlite/db/SQLiteCopyOpenHelperTest.kt
+++ b/library/src/test/java/com/github/reline/sqlite/db/SQLiteCopyOpenHelperTest.kt
@@ -36,8 +36,18 @@ class SQLiteCopyOpenHelperTest {
 
     @Test
     fun destructivelyMigrate() {
+        destructivelyMigrate(false)
+    }
+
+    @Test
+    fun destructivelyMigrateNoBackup() {
+        destructivelyMigrate(true)
+    }
+
+    private fun destructivelyMigrate(noBackupDirectory: Boolean) {
         val configBuilder = SupportSQLiteOpenHelper.Configuration.builder(context)
             .name("1.db")
+            .noBackupDirectory(noBackupDirectory)
 
         SQLiteCopyOpenHelper.Factory(context, CopyFromAssetPath("1.db"), FrameworkSQLiteOpenHelperFactory())
             .create(configBuilder.callback(TestCallback(1)).build())


### PR DESCRIPTION
Now SQLiteCopyOpenHelper correctly handles `SupportSQLiteOpenHelper.Configuration#useNoBackupDirectory` flag